### PR TITLE
Implement meeting creation API and update schema

### DIFF
--- a/back/MyJarvis/src/main/java/kr/or/iei/meeting/controller/MeetingController.java
+++ b/back/MyJarvis/src/main/java/kr/or/iei/meeting/controller/MeetingController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import kr.or.iei.common.model.dto.ResponseDTO;
 import kr.or.iei.meeting.model.dto.Meeting;
@@ -15,7 +16,7 @@ import kr.or.iei.meeting.model.service.MeetingService;
 
 @RestController
 @CrossOrigin("*")
-@RequestMapping("/member")
+@RequestMapping("/api/meetings")
 public class MeetingController {
 	
      @Autowired
@@ -26,8 +27,21 @@ public class MeetingController {
      public ResponseEntity<ResponseDTO> insertMeeting(@ModelAttribute Meeting meeting){
     	 ResponseDTO res = new ResponseDTO(HttpStatus.INTERNAL_SERVER_ERROR, "등록 중, 에러가 발생했습니다.!!", false, "error");
     	 
+    	 try {
+    		 
+    		 meeting.setMemberNo("1"); // ⭐ 테스트용 memberNo 하드코딩
+    		 int result = service.insertMeeting(meeting);
+    		 
+    		 if(result > 0) {
+    			 res = new ResponseDTO(HttpStatus.OK, "회의록 등록 완료", true, "success");
+    		 }else {
+    			res = new ResponseDTO(HttpStatus.OK, "등록 중, 오류 발생", false, "error"); 
+    		 }
+    	 }catch(Exception e) {
+    		 e.printStackTrace();
+    	 }
     	 
-    	 return null;
+    	 return new ResponseEntity<ResponseDTO>(res, res.getHttpStatus());
      }
      
      // 회의록 수정

--- a/back/MyJarvis/src/main/java/kr/or/iei/meeting/model/dao/MeetingDao.java
+++ b/back/MyJarvis/src/main/java/kr/or/iei/meeting/model/dao/MeetingDao.java
@@ -2,8 +2,11 @@ package kr.or.iei.meeting.model.dao;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import kr.or.iei.meeting.model.dto.Meeting;
+
 @Mapper
-public class MeetingDao { 
-	
+public interface MeetingDao {
+
+	int insertMeeting(Meeting meeting);
 	
 }

--- a/back/MyJarvis/src/main/java/kr/or/iei/meeting/model/dto/Meeting.java
+++ b/back/MyJarvis/src/main/java/kr/or/iei/meeting/model/dto/Meeting.java
@@ -11,11 +11,8 @@ public class Meeting {
 	
 	private String meetingNo;
 	private String memberNo;
-	private String clientNo;
-	private String compCd;
 	private String meetTitle;
 	private String meetContent;
-	private String meetingDate;
+	private String meetDate;
 	private String gptSummary;
-
 }

--- a/back/MyJarvis/src/main/java/kr/or/iei/meeting/model/service/MeetingService.java
+++ b/back/MyJarvis/src/main/java/kr/or/iei/meeting/model/service/MeetingService.java
@@ -2,14 +2,22 @@ package kr.or.iei.meeting.model.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import kr.or.iei.meeting.model.dao.MeetingDao;
+import kr.or.iei.meeting.model.dto.Meeting;
 
 @Service
 public class MeetingService {
 	
      @Autowired
      private MeetingDao dao;
+
+     @Transactional
+	public int insertMeeting(Meeting meeting) {
+    	  
+		return dao.insertMeeting(meeting);
+	}
      
      
      

--- a/back/MyJarvis/src/main/resources/mapper/meeing-mapper.xml
+++ b/back/MyJarvis/src/main/resources/mapper/meeing-mapper.xml
@@ -1,6 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
-<mapper namespace="">
+<mapper namespace="kr.or.iei.meeting.model.dao.MeetingDao">
 
+<!-- 회의록 등록 -->
+<insert id="insertMeeting"
+parameterType="Meeting">
+insert into tbl_meeting (
+    meeting_no,
+    meet_title,
+    meet_content,
+    meet_date,
+    gpt_summary
+  ) values (
+    SEQ_TBL_MEETING_NO.NEXTVAL,
+    #{meetTitle},
+    #{meetContent},
+    #{meetDate},
+    #{gptSummary}
+  )
+</insert>
 
 </mapper>

--- a/back/MyJarvis/src/main/resources/mapper/schedule-mapper.xml
+++ b/back/MyJarvis/src/main/resources/mapper/schedule-mapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
-<mapper namespace="">
+<mapper namespace="kr.or.iei.schedule.model.dao.ScheduleDao">
 
 
 </mapper>

--- a/front/MyJarvis/src/component/meeting/MeetingInsert.jsx
+++ b/front/MyJarvis/src/component/meeting/MeetingInsert.jsx
@@ -14,43 +14,52 @@ import './MeetingInsert.css';
 */
 
 // 회의록 등록/수정, 파일 업로드 폼
-function MeetingInsert({ setMeetings, setTab }) {
+function MeetingInsert({ setTab }) {
   const [title, setTitle] = useState('');
   const [date, setDate] = useState('');
   const [content, setContent] = useState('');
   const [file, setFile] = useState(null);
   const [participants, setParticipants] = useState('');
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    // 새 회의록 추가
-    setMeetings(prev => [
-      ...prev,
-      {
-        id: Date.now(),
-        title,
-        date,
-        content,
-        tags: [],
-        participants,
-        file,
-      },
-    ]);
-    setTitle('');
-    setDate('');
-    setContent('');
-    setParticipants('');
-    setFile(null);
-    alert('회의록이 등록되었습니다!');
-    if (setTab) setTab('list'); // 등록 후 목록 탭으로 자동 전환
+    // FormData로 파일 포함 데이터 전송
+    const formData = new FormData();
+    formData.append('meetTitle', title);
+    formData.append('meetDate', date);
+    formData.append('meetContent', content);
+    formData.append('participants', participants);
+
+    formData.append('memberNo', '1'); // 회원 번호 임시 지정. - 추후 삭제 해야 됨.
+    if (file) formData.append('file', file);
+
+    try {
+      const response = await fetch('/api/meetings', {
+        method: 'POST',
+        body: formData,
+      });
+      if (response.ok) {
+        alert('회의록이 등록되었습니다!');
+        setTitle('');
+        setDate('');
+        setContent('');
+        setParticipants('');
+        setFile(null);
+        if (setTab) setTab('list');
+      } else {
+        alert('등록 실패');
+      }
+    } catch (err) {
+      alert('서버 오류');
+    }
   };
 
   return (
     <form onSubmit={handleSubmit} className="meeting-insert-form">
       <h3>회의록 등록</h3>
-      <input placeholder="회의 제목" value={title} onChange={e => setTitle(e.target.value)} required />
-      <input type="date" value={date} onChange={e => setDate(e.target.value)} required />
-      <textarea placeholder="회의 내용" value={content} onChange={e => setContent(e.target.value)} rows={4} required />
+      <input placeholder="회의 제목" id="meetingTitle" value={title} onChange={e => setTitle(e.target.value)} required />
+      <input type="date" id="meetDate" value={date} onChange={e => setDate(e.target.value)} required />
+      <textarea placeholder="회의 내용" id="meetContent" value={content} onChange={e => setContent(e.target.value)} rows={4} required />
       <input placeholder="참여자(,로 구분)" value={participants} onChange={e => setParticipants(e.target.value)} />
       <input type="file" onChange={e => setFile(e.target.files[0])} />
       {file && <div>업로드 파일: {file.name}</div>}

--- a/front/MyJarvis/src/component/meeting/MeetingList.jsx
+++ b/front/MyJarvis/src/component/meeting/MeetingList.jsx
@@ -87,7 +87,7 @@ function MeetingList({ meetings, setMeetings, setTab, selected, setSelected, scr
             className={`meeting-list-item${selected && selected.id === m.id ? ' selected' : ''}`}
             onClick={() => setSelected(m)}
           >
-            <b>{m.title}</b> <span style={{ color: '#888', fontSize: '0.95em' }}>({m.date})</span><br />
+            <b className="meeting-title">{m.title}</b> <span className="meeting-date">({m.date})</span><br />
             <span>
               태그: {m.tags && m.tags.length > 0 ? m.tags.map((tag, idx) => (
                 <React.Fragment key={tag}>
@@ -98,7 +98,6 @@ function MeetingList({ meetings, setMeetings, setTab, selected, setSelected, scr
                         className="meeting-tag-remove"
                         onClick={e => { e.stopPropagation(); handleRemoveTag(m.id, tag); }}
                         title="태그 삭제"
-                        style={{ marginLeft: 2, color: '#888', background: 'none', border: 'none', cursor: 'pointer', fontSize: '1em' }}
                       >×</button>
                     )}
                   </span>

--- a/front/MyJarvis/vite.config.js
+++ b/front/MyJarvis/vite.config.js
@@ -1,7 +1,11 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    proxy: {
+      '/api': 'http://localhost' // Spring 서버가 포트 80이면 그대로
+    }
+  }
+});


### PR DESCRIPTION
Added backend API for meeting creation with MyBatis integration, including MeetingDao, service, and controller changes. Updated meeting DTO and SQL schema to simplify meeting and contract tables, added participant/target tables, and adjusted frontend to use the new API. Also configured Vite proxy for API requests.